### PR TITLE
Add LICENSE and fix d3 peerDep to v3

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2018 Daven Quinn
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "test": "mocha --compilers coffee:coffee-script/register"
   },
   "peerDependencies": {
-    "d3": "*"
+    "d3": "3.*.*"
   },
   "devDependencies": {
     "chai": "^3.5.0",


### PR DESCRIPTION
Hi Daven, I'm emailed you about the license of this repo a few years back when I created TernaryPlot.com, at the time you said I could create a pull request with an MIT license, which I promptly forgot to do! At the moment I'm working on a new d3-ternary-plot module, partly inspired by this one which reminded to make good on my promise. See a ([rough version of the module on Observable](https://observablehq.com/@julesblm/introducing-d3-ternary-plot-not-yet)) and [an example of the soil texture chart](https://observablehq.com/@julesblm/usda-soil-textural-triangle) using the new module. 

Also I'm looking for some input on the new module, so if you'd have time to take a look and give some feedback I'd really appreciate it! 